### PR TITLE
Initialize project structure with CI and tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+Provide a summary of the changes.
+
+## Testing
+- [ ] Unit tests
+- [ ] Linting
+
+## Checklist
+- [ ] My code follows the style guidelines
+- [ ] I have performed a self-review
+- [ ] I have added tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: |
+          pip install flake8
+          flake8 src tests
+      - name: Test
+        run: |
+          pip install pytest
+          pytest -q

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,11 @@
+name: Deploy
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Deploy placeholder
+        run: echo "Deploy step"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+data/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+venv/
+.envrc
+.ipynb_checkpoints/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+CMD ["bash"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+install:
+pip install -r requirements.txt
+
+test:
+pytest --maxfail=1 --disable-warnings -q
+
+lint:
+flake8 src tests
+
+build:
+docker build -t project-mvp .
+
+clean:
+rm -rf data/*.csv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Project MVP
+
+Prototype for scraping, ingestion, indexing and evaluation workflows.

--- a/config/devcontainer.json
+++ b/config/devcontainer.json
@@ -1,0 +1,1 @@
+{"name": "bio-devcontainer"}

--- a/config/environment.yml
+++ b/config/environment.yml
@@ -1,0 +1,4 @@
+name: bio-env
+dependencies:
+  - python=3.10
+

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -1,0 +1,12 @@
+version: 1
+formatters:
+  simple:
+    format: "%(levelname)s:%(name)s:%(message)s"
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: simple
+    level: DEBUG
+root:
+  handlers: [console]
+  level: INFO

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,3 @@
+# Architecture
+
+Describe system architecture here.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,3 @@
+# Setup
+
+Instructions for local or cloud setup.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,3 @@
+# Usage
+
+Examples of how to use the prototype.

--- a/notebooks/01_scraping.ipynb
+++ b/notebooks/01_scraping.ipynb
@@ -1,0 +1,1 @@
+{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 2}

--- a/notebooks/02_ingesta.ipynb
+++ b/notebooks/02_ingesta.ipynb
@@ -1,0 +1,1 @@
+{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 2}

--- a/notebooks/03_index_rag.ipynb
+++ b/notebooks/03_index_rag.ipynb
@@ -1,0 +1,1 @@
+{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 2}

--- a/notebooks/04_evaluacion_sugerencias.ipynb
+++ b/notebooks/04_evaluacion_sugerencias.ipynb
@@ -1,0 +1,1 @@
+{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 2}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+flake8
+faiss-cpu

--- a/scripts/run_index.sh
+++ b/scripts/run_index.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python -m src.index "$@"

--- a/scripts/run_scrape.sh
+++ b/scripts/run_scrape.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python -m src.scrape "$@"

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,0 +1,5 @@
+"""LLM evaluation utilities."""
+
+def evaluate(model_output):
+    """Placeholder evaluate function."""
+    return f"Evaluation result for {model_output}"

--- a/src/index.py
+++ b/src/index.py
@@ -1,0 +1,5 @@
+"""FAISS index utilities."""
+
+def build_index(data):
+    """Placeholder index building."""
+    return f"Index built for {len(data)} items"

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -1,0 +1,5 @@
+"""Ingest PDF/DOCX."""
+
+def ingest(file_path: str) -> str:
+    """Placeholder ingest function."""
+    return f"Ingested {file_path}"

--- a/src/scrape.py
+++ b/src/scrape.py
@@ -1,0 +1,5 @@
+"""Scraping utilities."""
+
+def scrape(url: str) -> str:
+    """Placeholder scrape function."""
+    return f"Scraped data from {url}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,4 @@
+from src.evaluate import evaluate
+
+def test_evaluate():
+    assert evaluate('output') == 'Evaluation result for output'

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,4 @@
+from src.index import build_index
+
+def test_build_index():
+    assert build_index([1,2,3]) == 'Index built for 3 items'

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,4 @@
+from src.ingest import ingest
+
+def test_ingest():
+    assert ingest('file.pdf') == 'Ingested file.pdf'

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -1,0 +1,4 @@
+from src.scrape import scrape
+
+def test_scrape():
+    assert scrape('http://example.com') == 'Scraped data from http://example.com'


### PR DESCRIPTION
## Summary
- scaffold directories like docs, notebooks, src, and tests
- add CI workflow for lint and pytest
- provide Makefile and Dockerfile
- include minimal placeholder implementations and passing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510c18030c832abf0b6bcd655ab9d4